### PR TITLE
Replace 'jcli certificate sign' step with 'jcli transaction auth'

### DIFF
--- a/scripts/createStakePool.sh
+++ b/scripts/createStakePool.sh
@@ -69,12 +69,8 @@ cat stake_pool.cert
 echo " ##4. Sign the Stake Pool certificate with the Stake Pool Owner private key"
 echo ${ACCOUNT_SK} > stake_key.sk
 
-cat stake_pool.cert | $CLI certificate sign stake_key.sk >stake_pool.signcert
-
-cat stake_pool.signcert
-
 echo " ##5. Send the signed Stake Pool certificate to the blockchain"
-./send-certificate.sh stake_pool.signcert ${REST_PORT} ${ACCOUNT_SK}
+./send-certificate.sh stake_pool.cert ${REST_PORT} stake_key.sk
 
 echo " ##6. Retrieve your stake pool id (NodeId)"
 cat stake_pool.cert | $CLI certificate get-stake-pool-id | tee stake_pool.id

--- a/scripts/send-certificate.sh
+++ b/scripts/send-certificate.sh
@@ -63,7 +63,8 @@ fi
 
 CERTIFICATE_PATH="$1"
 REST_PORT="$2"
-ACCOUNT_SK="$3"
+ACCOUNT_SK_PATH="$3"
+ACCOUNT_SK=$(cat ${ACCOUNT_SK_PATH})
 
 REST_URL="http://127.0.0.1:${REST_PORT}/api"
 
@@ -143,6 +144,7 @@ $CLI transaction info --fee-constant ${FEE_CONSTANT} --fee-coefficient ${FEE_COE
 
 echo " ##8. Finalize the transaction and send it to the blockchain"
 $CLI transaction seal --staging "${STAGING_FILE}"
+$CLI transaction auth -k "${ACCOUNT_SK_PATH}" --staging "${STAGING_FILE}"
 $CLI transaction to-message --staging "${STAGING_FILE}" | $CLI rest v0 message post -h "${REST_URL}"
 
 echo " ##9. Remove the temporary files"


### PR DESCRIPTION
As per https://github.com/input-output-hk/jormungandr/pull/1063, we no longer need certificate sign for a stake pool certificate. Instead, we use transaction auth.

Tested with jcli 0.7.0-rc7